### PR TITLE
ss/bugfix-2024-08

### DIFF
--- a/fitburst/analysis/fitter.py
+++ b/fitburst/analysis/fitter.py
@@ -484,6 +484,10 @@ class LSFitter:
             covariance = np.linalg.inv(0.5 * hessian)
             uncertainties = [float(x) for x in np.sqrt(np.diag(covariance)).tolist()]
 
+            if np.any(np.isnan(uncertainties)):
+                print("WARNING: one or more NaNs in exact uncertainties, replacing with approximates...")
+                uncertainties = [float(x) for x in np.sqrt(np.diag(covariance_approx)).tolist()]
+
             self.covariance_approx = covariance_approx
             self.covariance = covariance
             self.covariance_labels = par_labels

--- a/fitburst/analysis/model.py
+++ b/fitburst/analysis/model.py
@@ -342,19 +342,15 @@ class SpectrumModeler:
         # compute either Gaussian or pulse-broadening function, depending on inputs.
         profile = np.zeros(times_copy.shape, dtype=float)
         sc_time = sc_time_ref * (freqs / ref_freq) ** sc_index
-        threshold = general["thresholds"]["pbf_or_gaussian"]
+        normalize = general["flags"]["normalize_pbf"]
 
-        if np.any(sc_time < np.fabs(threshold * width)):
-            profile = rt.profile.compute_profile_gaussian(times_copy, arrival_time, width)
-
-        else:
-            # the following times array manipulates the times array so that we avoid a
-            # floating-point overlow in the exp((-times - toa) / sc_time) term in the
-            # PBF call. TODO: use a better, more transparent method for avoiding this.
+        if np.any(sc_time > 0.0):
             times_copy[times_copy < -5 * width] = -5 * width
             profile = rt.profile.compute_profile_pbf(
-                times_copy, arrival_time, width, freqs, ref_freq, sc_time_ref, sc_index=sc_index
+                times_copy, arrival_time, width, freqs, ref_freq, sc_time_ref, sc_index=sc_index, normalize=normalize
             )
+        else:
+            profile = rt.profile.compute_profile_gaussian(times_copy, arrival_time, width)
 
         # if data are folded and time/profile data contain two realizations, then
         # average along the appropriate axis to obtain a single realization.

--- a/fitburst/analysis/model.py
+++ b/fitburst/analysis/model.py
@@ -342,8 +342,9 @@ class SpectrumModeler:
         # compute either Gaussian or pulse-broadening function, depending on inputs.
         profile = np.zeros(times_copy.shape, dtype=float)
         sc_time = sc_time_ref * (freqs / ref_freq) ** sc_index
+        threshold = general["thresholds"]["pbf_or_gaussian"]
 
-        if np.any(sc_time < np.fabs(0.15 * width)):
+        if np.any(sc_time < np.fabs(threshold * width)):
             profile = rt.profile.compute_profile_gaussian(times_copy, arrival_time, width)
 
         else:

--- a/fitburst/backend/general.yaml
+++ b/fitburst/backend/general.yaml
@@ -8,5 +8,5 @@ constants:
     index_dispersion: -2.0
     index_scattering: -4.0
 
-thresholds:
-    pbf_or_gaussian: 0.05           # ratio of scattering timescale over burst width
+flags:
+    normalize_pbf: False

--- a/fitburst/backend/general.yaml
+++ b/fitburst/backend/general.yaml
@@ -7,3 +7,6 @@ constants:
     dispersion: 4149.377593360996   # in units of MHz**2 * s * cm**3 / pc
     index_dispersion: -2.0
     index_scattering: -4.0
+
+thresholds:
+    pbf_or_gaussian: 0.05           # ratio of scattering timescale over burst width

--- a/fitburst/pipelines/fitburst_pipeline.py
+++ b/fitburst/pipelines/fitburst_pipeline.py
@@ -540,6 +540,9 @@ for current_iteration in range(num_iterations):
                     current_uncertainties = bestfit_uncertainties[current_parameter_label]
                     print(f"    * {current_parameter_label}: {current_list} +/- {current_uncertainties}")        
 
+                print("INFO: ratio of hessian matrix (approximate / exact):")
+                print(fitter.hessian / fitter.hessian_approx)
+
             # now create plots.
             filename_elems = input_file.split(".")
             output_string = ".".join(filename_elems[:len(filename_elems)-1])
@@ -561,6 +564,9 @@ for current_iteration in range(num_iterations):
                         "initial_time": data.times_bin0,
                         "model_parameters": current_params,
                         "fit_statistics": fitter.fit_statistics,
+                        "fit_logistics" : {
+                            "weight_range" : weight_range,
+                        }
                     },
                     out,
                     indent=4

--- a/fitburst/routines/derivative.py
+++ b/fitburst/routines/derivative.py
@@ -1429,7 +1429,7 @@ def deriv2_model_wrt_burst_width_burst_width(parameters: dict, model: float, com
     """
 
     # define parameters and objects needed for mixed-derivative calculation.
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     burst_width = parameters["burst_width"][component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
@@ -1438,14 +1438,13 @@ def deriv2_model_wrt_burst_width_burst_width(parameters: dict, model: float, com
     ref_freq = parameters["ref_freq"][component]
     sc_index = parameters["scattering_index"][0] # global parameter.
     sc_time = parameters["scattering_timescale"][0] # global parameter.
-    spectral_index = parameters["spectral_index"][component]
-    spectral_running = parameters["spectral_running"][component]
     current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
 
     # now loop over each frequency and compute mixed-derivative array per channel.
     for freq in range(current_model.shape[0]):
         freq_ratio = model.freqs[freq] / ref_freq
         sc_time_freq = sc_time * freq_ratio ** sc_index
+        current_amplitude = amplitude[freq, :]
 
         # if scattering is not resolvable, then assume Gaussian temporal profile.
         if sc_time_freq < np.fabs(0.15 * burst_width):
@@ -1456,8 +1455,7 @@ def deriv2_model_wrt_burst_width_burst_width(parameters: dict, model: float, com
 
         else:
             # adjust time-difference values to make them friendly for error function.
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
             deriv_arg_erf = deriv_argument_erf(
                 "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -1500,7 +1498,7 @@ def deriv2_model_wrt_burst_width_arrival_time(parameters: dict, model: float, co
     """
 
     # define parameters and objects needed for mixed-derivative calculation.
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     burst_width = parameters["burst_width"][component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
@@ -1509,13 +1507,12 @@ def deriv2_model_wrt_burst_width_arrival_time(parameters: dict, model: float, co
     ref_freq = parameters["ref_freq"][component]
     sc_index = parameters["scattering_index"][0] # global parameter.
     sc_time = parameters["scattering_timescale"][0] # global parameter.
-    spectral_index = parameters["spectral_index"][component]
-    spectral_running = parameters["spectral_running"][component]
 
     # now loop over each frequency and compute mixed-derivative array per channel.
     for freq in range(current_model.shape[0]):
         freq_ratio = model.freqs[freq] / ref_freq
         sc_time_freq = sc_time * freq_ratio ** sc_index
+        current_amplitude = amplitude[freq, :]
 
         # if scattering is not resolvable, then assume Gaussian temporal profile.
         if sc_time_freq < np.fabs(0.15 * burst_width):
@@ -1525,8 +1522,7 @@ def deriv2_model_wrt_burst_width_arrival_time(parameters: dict, model: float, co
         else:
             # adjust time-difference values to make them friendly for error function.
             current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
             deriv_arg_erf = deriv_argument_erf(
                 "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -1568,7 +1564,7 @@ def deriv2_model_wrt_burst_width_scattering_timescale(parameters: dict, model: f
     """
 
     # define parameters and objects needed for mixed-derivative calculation.
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
     deriv_first = deriv_model_wrt_scattering_timescale(parameters, model, component, add_all = False)
@@ -1587,8 +1583,8 @@ def deriv2_model_wrt_burst_width_scattering_timescale(parameters: dict, model: f
     for freq in range(current_model.shape[0]):
         freq_ratio = model.freqs[freq] / ref_freq
         sc_time_freq = sc_time * freq_ratio ** sc_index
-        spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-        spectrum *= freq_ratio ** (-sc_index)
+        current_amplitude = amplitude[freq, :]
+        spectrum = current_amplitude * freq_ratio ** (-sc_index)
         arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
         deriv_arg_erf = deriv_argument_erf(
             "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -1631,7 +1627,7 @@ def deriv2_model_wrt_burst_width_scattering_index(parameters: dict, model: float
     """
 
     # define parameters and objects needed for mixed-derivative calculation.
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
     deriv_first = deriv_model_wrt_scattering_index(parameters, model, component, add_all = False)
@@ -1640,8 +1636,6 @@ def deriv2_model_wrt_burst_width_scattering_index(parameters: dict, model: float
     ref_freq = parameters["ref_freq"][component]
     sc_index = parameters["scattering_index"][0] # global parameter.
     sc_time = parameters["scattering_timescale"][0] # global parameter.
-    spectral_index = parameters["spectral_index"][component]
-    spectral_running = parameters["spectral_running"][component]
 
     # adjust time-difference values to make them friendly for error function.
     current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
@@ -1651,8 +1645,7 @@ def deriv2_model_wrt_burst_width_scattering_index(parameters: dict, model: float
         freq_ratio = model.freqs[freq] / ref_freq
         log_freq = np.log_freq_ratio
         sc_time_freq = sc_time * freq_ratio ** sc_index
-        spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-        spectrum *= freq_ratio ** (-sc_index)
+        spectrum = current_amplitude * freq_ratio ** (-sc_index)
         arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
         deriv_arg_erf = deriv_argument_erf(
             "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -1696,7 +1689,7 @@ def deriv2_model_wrt_burst_width_dm(parameters: dict, model: float, component: i
         The mixed derivative of the model evaluated over time and frequency
     """
 
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     burst_width = parameters["burst_width"][component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
@@ -1708,13 +1701,12 @@ def deriv2_model_wrt_burst_width_dm(parameters: dict, model: float, component: i
     ref_freq = parameters["ref_freq"][component]
     sc_index = parameters["scattering_index"][0] # global parameter.
     sc_time = parameters["scattering_timescale"][0] # global parameter.
-    spectral_index = parameters["spectral_index"][component] # global parameter.
-    spectral_running = parameters["spectral_running"][component] # global parameter.
 
     # now loop over each frequency and compute mixed-derivative array per channel.
     for freq in range(current_model.shape[0]):
         freq_ratio = model.freqs[freq] / ref_freq
         sc_time_freq = sc_time * freq_ratio ** sc_index
+        current_amplitude = amplitude[freq, :]
 
         # if scattering is not resolvable, then assume Gaussian temporal profile.
         if sc_time_freq < np.fabs(0.15 * burst_width):
@@ -1725,8 +1717,7 @@ def deriv2_model_wrt_burst_width_dm(parameters: dict, model: float, component: i
 
         else:
             # adjust time-difference values to make them friendly for error function.
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
             deriv_arg_erf = deriv_argument_erf(
                 "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -1767,7 +1758,7 @@ def deriv2_model_wrt_burst_width_dm_index(parameters: dict, model: float, compon
         The mixed derivative of the model evaluated over time and frequency
     """
 
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     burst_width = parameters["burst_width"][component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
@@ -1780,13 +1771,12 @@ def deriv2_model_wrt_burst_width_dm_index(parameters: dict, model: float, compon
     dm_index = parameters["dm_index"][0] # global parameter.
     sc_time = parameters["scattering_timescale"][0] # global parameter.
     sc_index = parameters["scattering_index"][0] # global parameter.
-    spectral_index = parameters["spectral_index"][component] # global parameter.
-    spectral_running = parameters["spectral_running"][component] # global parameter.
 
     # now loop over each frequency and compute mixed-derivative array per channel.
     for freq in range(current_model.shape[0]):
         freq_ratio = model.freqs[freq] / ref_freq
         sc_time_freq = sc_time * freq_ratio ** sc_index
+        current_amplitude = amplitude[freq, :]
 
         # if scattering is not resolvable, then assume Gaussian temporal profile.
         if sc_time_freq < np.fabs(0.15 * burst_width):
@@ -1796,8 +1786,7 @@ def deriv2_model_wrt_burst_width_dm_index(parameters: dict, model: float, compon
    
         else:
             # adjust time-difference values to make them friendly for error function.
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
             deriv_arg_erf = deriv_argument_erf(
                 "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -1838,7 +1827,7 @@ def deriv2_model_wrt_arrival_time_arrival_time(parameters: dict, model: float, c
         The mixed derivative of the model evaluated over time and frequency
     """
 
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     burst_width = parameters["burst_width"][component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
@@ -1847,22 +1836,20 @@ def deriv2_model_wrt_arrival_time_arrival_time(parameters: dict, model: float, c
     ref_freq = parameters["ref_freq"][component]
     sc_index = parameters["scattering_index"][0]
     sc_time = parameters["scattering_timescale"][0]
-    spectral_index = parameters["spectral_index"][component]
-    spectral_running = parameters["spectral_running"][component]
 
     deriv_mod = np.zeros((num_freq, num_time), dtype=float)
 
     for freq in range(num_freq):
         freq_ratio = model.freqs[freq] / ref_freq
         sc_time_freq = sc_time * freq_ratio ** sc_index
+        current_amplitude = amplitude[freq, :]
 
         if sc_time_freq < np.fabs(0.15 * burst_width):
             deriv_mod[freq, :] = current_timediff[freq, :] ** 2 * current_model[freq, :] / burst_width ** 4
             deriv_mod[freq, :] -= (current_model[freq, :] / burst_width ** 2)
 
         else:
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
             deriv_arg_erf = deriv_argument_erf(
                 "arrival_time", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -1902,7 +1889,7 @@ def deriv2_model_wrt_arrival_time_dm(parameters: dict, model: float, component: 
         The mixed derivative of the model evaluated over time and frequency
     """
 
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     burst_width = parameters["burst_width"][component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
@@ -1913,8 +1900,6 @@ def deriv2_model_wrt_arrival_time_dm(parameters: dict, model: float, component: 
     ref_freq = parameters["ref_freq"][component]
     sc_index = parameters["scattering_index"][0]
     sc_time = parameters["scattering_timescale"][0]
-    spectral_index = parameters["spectral_index"][component]
-    spectral_running = parameters["spectral_running"][component]
 
     # now loop over each frequency and compute mixed-derivative array per channel.
     deriv_timediff_wrt_dm = deriv_time_dm("dm", model.freqs, ref_freq, dm, dm_index)
@@ -1930,8 +1915,7 @@ def deriv2_model_wrt_arrival_time_dm(parameters: dict, model: float, component: 
         else:
             # adjust time-difference values to make them friendly for error function.
             current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
             deriv_arg_erf = deriv_argument_erf(
                 "arrival_time", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -2007,7 +1991,7 @@ def deriv2_model_wrt_arrival_time_scattering_timescale(parameters: dict, model: 
         The mixed derivative of the model evaluated over time and frequency
     """
 
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     burst_width = parameters["burst_width"][component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
@@ -2019,8 +2003,6 @@ def deriv2_model_wrt_arrival_time_scattering_timescale(parameters: dict, model: 
     dm_index = parameters["dm_index"][0] # global parameter.
     sc_time = parameters["scattering_timescale"][0] # global parameter.
     sc_index = parameters["scattering_index"][0] # global parameter.
-    spectral_index = parameters["spectral_index"][component] # global parameter.
-    spectral_running = parameters["spectral_running"][component] # global parameter.
 
     # adjust time-difference values to make them friendly for error function.
     current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
@@ -2029,8 +2011,8 @@ def deriv2_model_wrt_arrival_time_scattering_timescale(parameters: dict, model: 
     for freq in range(current_model.shape[0]):
         freq_ratio = model.freqs[freq] / ref_freq
         sc_time_freq = sc_time * freq_ratio ** sc_index
-        spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-        spectrum *= freq_ratio ** (-sc_index)
+        current_amplitude = amplitude[freq, :]
+        spectrum = current_amplitude * freq_ratio ** (-sc_index)
         arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
         deriv_arg_erf = deriv_argument_erf(
             "arrival_time", model.freqs[freq], current_timediff[freq, :], parameters, component
@@ -2072,7 +2054,7 @@ def deriv2_model_wrt_arrival_time_scattering_index(parameters: dict, model: floa
         The mixed derivative of the model evaluated over time and frequency
     """
 
-    amplitude = parameters["amplitude"][component]
+    amplitude = model.amplitude_per_component[:, :, component]
     burst_width = parameters["burst_width"][component]
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
@@ -2084,8 +2066,6 @@ def deriv2_model_wrt_arrival_time_scattering_index(parameters: dict, model: floa
     dm_index = parameters["dm_index"][0] # global parameter.
     sc_time = parameters["scattering_timescale"][0] # global parameter.
     sc_index = parameters["scattering_index"][0] # global parameter.
-    spectral_index = parameters["spectral_index"][component] # global parameter.
-    spectral_running = parameters["spectral_running"][component] # global parameter.
 
     # adjust time-difference values to make them friendly for error function.
     current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
@@ -2094,8 +2074,8 @@ def deriv2_model_wrt_arrival_time_scattering_index(parameters: dict, model: floa
     for freq in range(current_model.shape[0]):
         freq_ratio = model.freqs[freq] / ref_freq
         sc_time_freq = sc_time * freq_ratio ** sc_index
-        spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-        spectrum *= freq_ratio ** (-sc_index)
+        current_amplitude = amplitude[freq, :]
+        spectrum = current_amplitude * freq_ratio ** (-sc_index)
         erf_arg = (current_timediff[freq, :] - burst_width ** 2 / sc_time_freq) / burst_width / np.sqrt(2)
         erf_arg_deriv = burst_width * np.log(freq_ratio) / sc_time_freq / np.sqrt(2)
         exp_arg = burst_width ** 2 / 2 / sc_time_freq ** 2 - \
@@ -2179,14 +2159,12 @@ def deriv2_model_wrt_dm_dm(parameters: dict, model: float, component: int = 0) -
     sc_time = parameters["scattering_timescale"][0]
 
     for current_component in range(model.spectrum_per_component.shape[2]):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_model = model.spectrum_per_component[:, :, current_component]
         current_timediff = model.timediff_per_component[:, :, current_component]
         deriv_first = deriv_model_wrt_dm(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
 
         # now loop over each frequency and compute mixed-derivative array per channel.
         deriv_timediff_wrt_dm = deriv_time_dm("dm", model.freqs, ref_freq, dm, dm_index)
@@ -2195,6 +2173,7 @@ def deriv2_model_wrt_dm_dm(parameters: dict, model: float, component: int = 0) -
             freq_ratio = model.freqs[freq] / ref_freq
             freq_diff = model.freqs[freq] ** dm_index - ref_freq ** dm_index
             sc_time_freq = sc_time * freq_ratio ** sc_index
+            current_amplitude = amplitude[freq, :]
 
             if sc_time_freq < np.fabs(0.15 * burst_width):
                 deriv_mod_int[freq, :, current_component] = (deriv_timediff_wrt_dm[freq] * current_timediff[freq, :]) ** 2 * \
@@ -2204,8 +2183,7 @@ def deriv2_model_wrt_dm_dm(parameters: dict, model: float, component: int = 0) -
             else:
                 # adjust time-difference values to make them friendly for error function.
                 current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
-                spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-                spectrum *= freq_ratio ** (-sc_index)
+                spectrum = current_amplitude * freq_ratio ** (-sc_index)
                 arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
                 deriv_arg_erf = deriv_argument_erf(
                     "dm", model.freqs[freq], current_timediff[freq, :], parameters, current_component
@@ -2253,19 +2231,17 @@ def deriv2_model_wrt_scattering_timescale_scattering_timescale(parameters: dict,
     deriv_mod_int = np.zeros((num_freq, num_time, num_component), dtype=float)
 
     for current_component in range(num_component):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         deriv_first = deriv_model_wrt_dm_index(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
 
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq
             sc_time_freq = sc_time * freq_ratio ** sc_index
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            current_amplitude = amplitude[freq, :]
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
             deriv_arg_erf = deriv_argument_erf(
                 "scattering_timescale", model.freqs[freq], current_timediff[freq, :], parameters, current_component
@@ -2319,17 +2295,16 @@ def deriv2_model_wrt_scattering_timescale_scattering_index(parameters: dict, mod
     deriv_mod_int = np.zeros((num_freq, num_time, num_component), dtype=float)
 
     for current_component in range(num_component):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         deriv_first = deriv_model_wrt_scattering_index(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
 
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq
             sc_time_freq = sc_time * freq_ratio ** sc_index
+            current_amplitude = amplitude[freq, :]
             term0 = (-1 / sc_time - burst_width ** 2 / sc_time_freq ** 2 / sc_time + current_timediff[freq, :] / \
                     sc_time / sc_time_freq)
             term0_deriv = 2 * (burst_width / sc_time_freq) ** 2 / sc_time * np.log(freq_ratio) - \
@@ -2337,8 +2312,7 @@ def deriv2_model_wrt_scattering_timescale_scattering_index(parameters: dict, mod
             erf_arg = (current_timediff[freq, :] / burst_width - burst_width / sc_time_freq) / np.sqrt(2)
             erf_arg_deriv = burst_width * np.log(freq_ratio) / sc_time_freq / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             exp_arg_deriv = -(burst_width / sc_time_freq) ** 2 * np.log(freq_ratio) + current_timediff[freq, :] * \
                             np.log(freq_ratio) / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
@@ -2381,22 +2355,20 @@ def deriv2_model_wrt_scattering_timescale_dm(parameters: dict, model: float, com
     deriv_mod_int = np.zeros((num_freq, num_time, num_component), dtype=float)
 
     for current_component in range(num_component):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_model = model.spectrum_per_component[:, :, current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         deriv_first = deriv_model_wrt_scattering_timescale(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
         deriv_timediff_wrt_dm = deriv_time_dm("dm", model.freqs, ref_freq, dm, dm_index)
 
         # TODO: replace lines below.
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq
             sc_time_freq = sc_time * freq_ratio ** sc_index
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            current_amplitude = amplitude[freq, :]
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
             deriv_arg_erf = deriv_argument_erf(
                 "dm", model.freqs[freq], current_timediff[freq, :], parameters, current_component
@@ -2448,27 +2420,25 @@ def deriv2_model_wrt_scattering_timescale_dm_index(parameters: dict, model: floa
     deriv_mod_int = np.zeros((num_freq, num_time, num_component), dtype=float)
 
     for current_component in range(num_component):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         deriv_first = deriv_model_wrt_dm_index(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
 
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq
             freq_diff = np.log(model.freqs[freq]) * model.freqs[freq] ** dm_index - \
                         np.log(ref_freq) * ref_freq ** dm_index
             sc_time_freq = sc_time * freq_ratio ** sc_index
+            current_amplitude = amplitude[freq, :]
             term0 = (-1 / sc_time - burst_width ** 2 / sc_time_freq ** 2 / sc_time + current_timediff[freq, :] / \
                     sc_time / sc_time_freq)
             term0_deriv = -dm_const * dm * freq_diff / sc_time_freq / sc_time
             erf_arg = (current_timediff[freq, :] / burst_width - burst_width / sc_time_freq) / np.sqrt(2)
             erf_arg_deriv = -dm_const * dm * freq_diff / burst_width / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             exp_arg_deriv = dm_const * dm * freq_diff / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
             term1 = term0_deriv * model.spectrum_per_component[freq, :, current_component]
@@ -2509,18 +2479,17 @@ def deriv2_model_wrt_scattering_index_scattering_index(parameters: dict, model: 
     deriv_mod_int = np.zeros((num_freq, num_time, num_component), dtype=float)
 
     for current_component in range(num_component):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         deriv_first = deriv_model_wrt_scattering_index(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
 
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq
             freq_diff = np.log(model.freqs[freq]) * model.freqs[freq] ** dm_index - \
                         np.log(ref_freq) * ref_freq ** dm_index
+            current_amplitude = amplitude[freq, :]
             sc_time_freq = sc_time * freq_ratio ** sc_index
             term0 = -(1 + burst_width ** 2 / sc_time_freq ** 2 - current_timediff[freq, :] / sc_time_freq) * np.log(freq_ratio)
             term0_deriv = -np.log(freq_ratio) * (-2 * np.log(freq_ratio) * (burst_width / sc_time_freq) ** 2 + \
@@ -2528,8 +2497,7 @@ def deriv2_model_wrt_scattering_index_scattering_index(parameters: dict, model: 
             erf_arg = (current_timediff[freq, :] / burst_width - burst_width / sc_time_freq) / np.sqrt(2)
             erf_arg_deriv = burst_width * np.log(freq_ratio) / sc_time_freq / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             exp_arg_deriv = -np.log(freq_ratio) * (burst_width / sc_time_freq) ** 2 + \
                             current_timediff[freq, :] * np.log(freq_ratio) / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
@@ -2573,25 +2541,23 @@ def deriv2_model_wrt_scattering_index_dm(parameters: dict, model: float, compone
     deriv_mod_int = np.zeros((num_freq, num_time, num_component), dtype=float)
 
     for current_component in range(num_component):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         deriv_first = deriv_model_wrt_dm(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
 
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq
             freq_diff = model.freqs[freq] ** dm_index - ref_freq ** dm_index
+            current_amplitude = amplitude[freq, :]
             sc_time_freq = sc_time * freq_ratio ** sc_index
             term0 = -(1 + burst_width ** 2 / sc_time_freq ** 2 - current_timediff[freq, :] / sc_time_freq) * np.log(freq_ratio)
             term0_deriv = -np.log(freq_ratio) * dm_const * freq_diff / sc_time_freq
             erf_arg = (current_timediff[freq, :] / burst_width - burst_width / sc_time_freq) / np.sqrt(2)
             erf_arg_deriv = -dm_const * freq_diff / burst_width / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             exp_arg_deriv = dm_const * freq_diff / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
             term1 = term0_deriv * model.spectrum_per_component[freq, :, current_component]
@@ -2632,26 +2598,24 @@ def deriv2_model_wrt_scattering_index_dm_index(parameters: dict, model: float, c
     deriv_mod_int = np.zeros((num_freq, num_time, num_component), dtype=float)
 
     for current_component in range(num_component):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         deriv_first = deriv_model_wrt_dm_index(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
 
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq
             freq_diff = np.log(model.freqs[freq]) * model.freqs[freq] ** dm_index - \
                         np.log(ref_freq) * ref_freq ** dm_index
+            current_amplitude = amplitude[freq, :]
             sc_time_freq = sc_time * freq_ratio ** sc_index
             term0 = -(1 + burst_width ** 2 / sc_time_freq ** 2 - current_timediff[freq, :] / sc_time_freq) * np.log(freq_ratio)
             term0_deriv = -np.log(freq_ratio) * dm_const * dm * freq_diff / sc_time_freq
             erf_arg = (current_timediff[freq, :] / burst_width - burst_width / sc_time_freq) / np.sqrt(2)
             erf_arg_deriv = -dm_const * dm * freq_diff / burst_width / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             exp_arg_deriv = dm_const * dm * freq_diff / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
             term1 = term0_deriv * model.spectrum_per_component[freq, :, current_component]
@@ -2692,21 +2656,19 @@ def deriv2_model_wrt_dm_index_dm_index(parameters: dict, model: float, component
 
 
     for current_component in range(num_component):
-        amplitude = parameters["amplitude"][current_component]
+        amplitude = model.amplitude_per_component[:, :, current_component]
         burst_width = parameters["burst_width"][current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         deriv_first = deriv_model_wrt_dm_index(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
-        spectral_index = parameters["spectral_index"][current_component]
-        spectral_running = parameters["spectral_running"][current_component]
 
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq
             sc_time_freq = sc_time * freq_ratio ** sc_index
+            current_amplitude = amplitude[freq, :]
             erf_arg = (current_timediff[freq, :] / burst_width - burst_width / sc_time_freq) / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
-            spectrum = 10 ** amplitude * freq_ratio ** (spectral_index + spectral_running * np.log(freq_ratio))
-            spectrum *= freq_ratio ** (-sc_index)
+            spectrum = current_amplitude * freq_ratio ** (-sc_index)
             product = dm_const * dm * (np.log(model.freqs[freq]) * model.freqs[freq] ** dm_index -\
                       np.log(ref_freq) * ref_freq ** dm_index)
             product_deriv = dm_const * dm * (np.log(model.freqs[freq]) ** 2 * model.freqs[freq] ** dm_index -\

--- a/fitburst/routines/derivative.py
+++ b/fitburst/routines/derivative.py
@@ -794,7 +794,7 @@ def deriv_model_wrt_scattering_timescale(parameters: dict, model: float, compone
 
         # now compute derivative contribution from current component.
         # TODO: figure out work-around for overflow in 'term1' for low scattering timescales.
-        term1 = 0.0 #deriv_amp_pbf * np.exp(arg_exp_model) * (1 + ss.erf(arg_erf))
+        term1 = deriv_amp_pbf * np.exp(arg_exp_model) * (1 + ss.erf(arg_erf))
         term2 = (-(burst_width / sc_times_freq[idx_sc, None]) ** 2 + current_timediff[idx_sc, :] / sc_times_freq[idx_sc, None]) * \
                 current_model[idx_sc, :] / sc_time
         term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * 2 / np.sqrt(np.pi)
@@ -1567,6 +1567,7 @@ def deriv2_model_wrt_burst_width_burst_width(parameters: dict, model: float, com
             # adjust time-difference values to make them friendly for error function.
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+            amp_pbf = freq_ratio ** (-sc_index)
             deriv_arg_erf = deriv_argument_erf(
                 "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
             )
@@ -1580,8 +1581,8 @@ def deriv2_model_wrt_burst_width_burst_width(parameters: dict, model: float, com
             # now define terms that contribute to mixed derivative.
             term1 = current_model[freq, :] / sc_time_freq ** 2
             term2 = burst_width * deriv_first[freq, :] / sc_time_freq ** 2
-            term3 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-            term4 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+            term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+            term4 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
             deriv_mod[freq, :] = term1 + term2 + term3 + term4
 
     return deriv_mod
@@ -1634,6 +1635,7 @@ def deriv2_model_wrt_burst_width_arrival_time(parameters: dict, model: float, co
             current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+            amp_pbf = freq_ratio ** (-sc_index)
             deriv_arg_erf = deriv_argument_erf(
                 "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
             )
@@ -1646,8 +1648,8 @@ def deriv2_model_wrt_burst_width_arrival_time(parameters: dict, model: float, co
 
             # now define terms that contriubte to mixed-partial derivative.
             term1 = burst_width * deriv_first[freq, :] / sc_time_freq ** 2
-            term2 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-            term3 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+            term2 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+            term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
             deriv_mod[freq, :] = term1 + term2 + term3
 
     return deriv_mod
@@ -1695,6 +1697,7 @@ def deriv2_model_wrt_burst_width_scattering_timescale(parameters: dict, model: f
         sc_time_freq = sc_time * freq_ratio ** sc_index
         spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
         arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+        amp_pbf = freq_ratio ** (-sc_index)
         deriv_arg_erf = deriv_argument_erf(
             "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
         )
@@ -1708,8 +1711,8 @@ def deriv2_model_wrt_burst_width_scattering_timescale(parameters: dict, model: f
         # now define terms that contriubte to mixed-partial derivative.
         term1 = -2 * burst_width * current_model[freq, :] / sc_time / sc_time_freq ** 2
         term2 = burst_width * deriv_first[freq, :] / sc_time_freq ** 2
-        term3 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-        term4 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+        term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+        term4 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
         deriv_mod[freq, :] = term1 + term2 + term3 + term4
 
     return deriv_mod
@@ -1756,6 +1759,7 @@ def deriv2_model_wrt_burst_width_scattering_index(parameters: dict, model: float
         sc_time_freq = sc_time * freq_ratio ** sc_index
         spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
         arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+        amp_pbf = freq_ratio ** (-sc_index)
         deriv_arg_erf = deriv_argument_erf(
             "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
         )
@@ -1769,9 +1773,9 @@ def deriv2_model_wrt_burst_width_scattering_index(parameters: dict, model: float
         # now define terms that contriubte to mixed-partial derivative.
         term1 = -2 * log_freq * burst_width * current_model[freq, :] / sc_time_freq ** 2
         term2 = burst_width * deriv_first[freq, :] / sc_time_freq ** 2
-        term3 = -spectrum * np.exp(arg_exp) * deriv_arg_erf * log_freq * 2 / np.sqrt(np.pi)
-        term4 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-        term5 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+        term3 = -spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * log_freq * 2 / np.sqrt(np.pi)
+        term4 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+        term5 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
 
         deriv_mod[freq, :] = term1 + term2 + term3 + term4 + term5
 
@@ -1828,6 +1832,7 @@ def deriv2_model_wrt_burst_width_dm(parameters: dict, model: float, component: i
             # adjust time-difference values to make them friendly for error function.
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+            amp_pbf = freq_ratio ** (-sc_index)
             deriv_arg_erf = deriv_argument_erf(
                 "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
             )
@@ -1840,8 +1845,8 @@ def deriv2_model_wrt_burst_width_dm(parameters: dict, model: float, component: i
 
             # now define terms that contriubte to mixed-partial derivative.
             term1 = burst_width * current_model[freq, :] / sc_time_freq ** 2
-            term2 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-            term3 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+            term2 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+            term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
             deriv_mod[freq, :] = term1 + term2 + term3
 
     return deriv_mod
@@ -1897,6 +1902,7 @@ def deriv2_model_wrt_burst_width_dm_index(parameters: dict, model: float, compon
             # adjust time-difference values to make them friendly for error function.
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+            amp_pbf = freq_ratio ** (-sc_index)
             deriv_arg_erf = deriv_argument_erf(
                 "burst_width", model.freqs[freq], current_timediff[freq, :], parameters, component
             )
@@ -1909,8 +1915,8 @@ def deriv2_model_wrt_burst_width_dm_index(parameters: dict, model: float, compon
 
             # now define terms that contriubte to mixed-partial derivative.
             term1 = burst_width * deriv_first[freq, :] / sc_time_freq ** 2
-            term2 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-            term3 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+            term2 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+            term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
 
             deriv_mod[freq, :] = term1 + term2 + term3
  
@@ -1960,6 +1966,7 @@ def deriv2_model_wrt_arrival_time_arrival_time(parameters: dict, model: float, c
         else:
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+            amp_pbf = freq_ratio ** (-sc_index)
             deriv_arg_erf = deriv_argument_erf(
                 "arrival_time", model.freqs[freq], current_timediff[freq, :], parameters, component
             )
@@ -1971,8 +1978,8 @@ def deriv2_model_wrt_arrival_time_arrival_time(parameters: dict, model: float, c
             )
 
             term1 = deriv_first[freq, :] / sc_time_freq
-            term2 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-            term3 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+            term2 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+            term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
             deriv_mod[freq, :] = term1 + term2 + term3
 
     return deriv_mod
@@ -2027,6 +2034,7 @@ def deriv2_model_wrt_arrival_time_dm(parameters: dict, model: float, component: 
             current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+            amp_pbf = freq_ratio ** (-sc_index)
             deriv_arg_erf = deriv_argument_erf(
                 "arrival_time", model.freqs[freq], current_timediff[freq, :], parameters, component
             )
@@ -2039,8 +2047,8 @@ def deriv2_model_wrt_arrival_time_dm(parameters: dict, model: float, component: 
 
             # now define terms that contriubte to mixed-partial derivative.
             term1 = deriv_first[freq, :] / sc_time_freq
-            term2 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-            term3 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+            term2 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+            term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
             deriv_mod[freq, :] = term1 + term2 + term3
 
     return deriv_mod
@@ -2123,6 +2131,7 @@ def deriv2_model_wrt_arrival_time_scattering_timescale(parameters: dict, model: 
         sc_time_freq = sc_time * freq_ratio ** sc_index
         spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
         arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+        amp_pbf = freq_ratio ** (-sc_index)
         deriv_arg_erf = deriv_argument_erf(
             "arrival_time", model.freqs[freq], current_timediff[freq, :], parameters, component
         )
@@ -2136,8 +2145,8 @@ def deriv2_model_wrt_arrival_time_scattering_timescale(parameters: dict, model: 
         # now define terms that contriubte to mixed-partial derivative.
         term1 = -model.spectrum_per_component[freq, :, component] / sc_time / sc_time_freq
         term2 = deriv_first[freq, :] / sc_time_freq
-        term3 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-        term4 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+        term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+        term4 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
         deriv_mod[freq, :] = term1 + term2 + term3 + term4
 
     return deriv_mod
@@ -2293,6 +2302,7 @@ def deriv2_model_wrt_dm_dm(parameters: dict, model: float, component: int = 0) -
                 current_timediff[current_timediff < -5 * burst_width] = -5 * burst_width
                 spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
                 arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+                amp_pbf = freq_ratio ** (-sc_index)
                 deriv_arg_erf = deriv_argument_erf(
                     "dm", model.freqs[freq], current_timediff[freq, :], parameters, current_component
                 )
@@ -2304,8 +2314,8 @@ def deriv2_model_wrt_dm_dm(parameters: dict, model: float, component: int = 0) -
                 )
 
                 term1 = -deriv_timediff_wrt_dm[freq] * deriv_first[freq, :] / sc_time_freq
-                term2 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-                term3 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi) 
+                term2 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+                term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi) 
                 deriv_mod_int[freq, :, current_component] = term1 + term2 + term3
 
     return np.sum(deriv_mod_int, axis = 2)
@@ -2350,6 +2360,7 @@ def deriv2_model_wrt_scattering_timescale_scattering_timescale(parameters: dict,
             sc_time_freq = sc_time * freq_ratio ** sc_index
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+            amp_pbf = freq_ratio ** (-sc_index)
             deriv_arg_erf = deriv_argument_erf(
                 "scattering_timescale", model.freqs[freq], current_timediff[freq, :], parameters, current_component
             )
@@ -2366,8 +2377,8 @@ def deriv2_model_wrt_scattering_timescale_scattering_timescale(parameters: dict,
                            (-current_timediff[freq, :] / sc_time_freq + 2 * (burst_width / sc_time_freq) ** 2) / sc_time ** 2
             term1 = term0_deriv * model.spectrum_per_component[freq, :, current_component]
             term2 = term0 * deriv_first[freq, :]
-            term3 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-            term4 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+            term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+            term4 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
 
             deriv_mod_int[freq, :, current_component] = term1 + term2 + term3 + term4
 
@@ -2475,6 +2486,7 @@ def deriv2_model_wrt_scattering_timescale_dm(parameters: dict, model: float, com
             sc_time_freq = sc_time * freq_ratio ** sc_index
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
             arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
+            amp_pbf = freq_ratio ** (-sc_index)
             deriv_arg_erf = deriv_argument_erf(
                 "dm", model.freqs[freq], current_timediff[freq, :], parameters, current_component
             )
@@ -2487,8 +2499,8 @@ def deriv2_model_wrt_scattering_timescale_dm(parameters: dict, model: float, com
 
             term1 = -deriv_timediff_wrt_dm[freq] * deriv_first[freq, :] / sc_time_freq
             term2 = deriv_timediff_wrt_dm[freq] * current_model[freq, :] / sc_time / sc_time_freq
-            term3 = spectrum * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
-            term4 = spectrum * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
+            term3 = spectrum * amp_pbf * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
+            term4 = spectrum * amp_pbf * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
 
             deriv_mod_int[freq, :, current_component] = term1 + term2 + term3 + term4
 
@@ -2543,11 +2555,12 @@ def deriv2_model_wrt_scattering_timescale_dm_index(parameters: dict, model: floa
             erf_arg_deriv = -dm_const * dm * freq_diff / burst_width / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
+            amp_pbf = freq_ratio ** (-sc_index)
             exp_arg_deriv = dm_const * dm * freq_diff / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
             term1 = term0_deriv * model.spectrum_per_component[freq, :, current_component]
             term2 = term0 * deriv_first[freq, :]
-            term3 = np.sqrt(2 / np.pi) * spectrum * burst_width * np.exp(exp_arg) * exp_arg_deriv / sc_time_freq / sc_time
+            term3 = np.sqrt(2 / np.pi) * spectrum * amp_pbf * burst_width * np.exp(exp_arg) * exp_arg_deriv / sc_time_freq / sc_time
 
             deriv_mod_int[freq, :, current_component] = term1 + term2 + term3
 
@@ -2601,13 +2614,14 @@ def deriv2_model_wrt_scattering_index_scattering_index(parameters: dict, model: 
             erf_arg_deriv = burst_width * np.log(freq_ratio) / sc_time_freq / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
+            amp_pbf = freq_ratio ** (-sc_index)
             exp_arg_deriv = -np.log(freq_ratio) * (burst_width / sc_time_freq) ** 2 + \
                             current_timediff[freq, :] * np.log(freq_ratio) / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
             term1 = term0_deriv * model.spectrum_per_component[freq, :, current_component]
             term2 = term0 * deriv_first[freq, :]
-            term3 = -np.sqrt(2 / np.pi) * spectrum * burst_width * np.exp(exp_arg) * np.log(freq_ratio) ** 2 / sc_time_freq 
-            term4 = np.sqrt(2 / np.pi) * spectrum * burst_width * np.exp(exp_arg) * np.log(freq_ratio) * exp_arg_deriv / sc_time_freq 
+            term3 = -np.sqrt(2 / np.pi) * spectrum * amp_pbf * burst_width * np.exp(exp_arg) * np.log(freq_ratio) ** 2 / sc_time_freq 
+            term4 = np.sqrt(2 / np.pi) * spectrum * amp_pbf * burst_width * np.exp(exp_arg) * np.log(freq_ratio) * exp_arg_deriv / sc_time_freq 
 
             deriv_mod_int[freq, :, current_component] = term1 + term2 + term3 + term4
 
@@ -2660,11 +2674,12 @@ def deriv2_model_wrt_scattering_index_dm(parameters: dict, model: float, compone
             erf_arg_deriv = -dm_const * freq_diff / burst_width / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
+            amp_pbf = freq_ratio ** (-sc_index)
             exp_arg_deriv = dm_const * freq_diff / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
             term1 = term0_deriv * model.spectrum_per_component[freq, :, current_component]
             term2 = term0 * deriv_first[freq, :]
-            term3 = np.sqrt(2 / np.pi) * spectrum * burst_width * np.exp(exp_arg) * np.log(freq_ratio) * exp_arg_deriv / sc_time_freq 
+            term3 = np.sqrt(2 / np.pi) * spectrum * amp_pbf * burst_width * np.exp(exp_arg) * np.log(freq_ratio) * exp_arg_deriv / sc_time_freq 
             deriv_mod_int[freq, :, current_component] = term1 + term2 + term3
 
     return np.sum(deriv_mod_int, axis = 2)
@@ -2717,11 +2732,12 @@ def deriv2_model_wrt_scattering_index_dm_index(parameters: dict, model: float, c
             erf_arg_deriv = -dm_const * dm * freq_diff / burst_width / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
+            amp_pbf = freq_ratio ** (-sc_index)
             exp_arg_deriv = dm_const * dm * freq_diff / sc_time_freq - 2 * erf_arg * erf_arg_deriv
 
             term1 = term0_deriv * model.spectrum_per_component[freq, :, current_component]
             term2 = term0 * deriv_first[freq, :]
-            term3 = np.sqrt(2 / np.pi) * spectrum * burst_width * np.exp(exp_arg) * np.log(freq_ratio) * exp_arg_deriv / sc_time_freq 
+            term3 = np.sqrt(2 / np.pi) * spectrum * amp_pbf * burst_width * np.exp(exp_arg) * np.log(freq_ratio) * exp_arg_deriv / sc_time_freq 
             deriv_mod_int[freq, :, current_component] = term1 + term2 + term3
 
     return np.sum(deriv_mod_int, axis = 2)
@@ -2769,6 +2785,7 @@ def deriv2_model_wrt_dm_index_dm_index(parameters: dict, model: float, component
             erf_arg = (current_timediff[freq, :] / burst_width - burst_width / sc_time_freq) / np.sqrt(2)
             exp_arg = (burst_width / sc_time_freq) ** 2 / 2 - current_timediff[freq, :] / sc_time_freq - erf_arg ** 2
             spectrum = current_amplitude[freq, :] #* freq_ratio ** (-sc_index)
+            amp_pbf = freq_ratio ** (-sc_index)
             product = dm_const * dm * (np.log(model.freqs[freq]) * model.freqs[freq] ** dm_index -\
                       np.log(ref_freq) * ref_freq ** dm_index)
             product_deriv = dm_const * dm * (np.log(model.freqs[freq]) ** 2 * model.freqs[freq] ** dm_index -\
@@ -2777,8 +2794,8 @@ def deriv2_model_wrt_dm_index_dm_index(parameters: dict, model: float, component
 
             term1 = product_deriv * model.spectrum_per_component[freq, :, current_component] / sc_time_freq
             term2 = product * deriv_first[freq, :] / sc_time_freq
-            term3 = -np.sqrt(2 / np.pi) * product_deriv * spectrum * np.exp(exp_arg) / burst_width / sc_time_freq
-            term4 = -np.sqrt(2 / np.pi) * product * spectrum * np.exp(exp_arg) / burst_width / sc_time_freq * exp_arg_deriv
+            term3 = -np.sqrt(2 / np.pi) * product_deriv * spectrum * amp_pbf * np.exp(exp_arg) / burst_width / sc_time_freq
+            term4 = -np.sqrt(2 / np.pi) * product * spectrum * amp_pbf * np.exp(exp_arg) / burst_width / sc_time_freq * exp_arg_deriv
             deriv_mod_int[freq, :, current_component] = term1 + term2 + term3 + term4
 
     return np.sum(deriv_mod_int, axis = 2)

--- a/fitburst/routines/derivative.py
+++ b/fitburst/routines/derivative.py
@@ -1723,7 +1723,7 @@ def deriv2_model_wrt_burst_width_scattering_index(parameters: dict, model: float
     # now loop over each frequency and compute mixed-derivative array per channel.
     for freq in range(current_model.shape[0]):
         freq_ratio = model.freqs[freq] / ref_freq
-        log_freq = np.log_freq_ratio
+        log_freq = np.log(freq_ratio)
         sc_time_freq = sc_time * freq_ratio ** sc_index
         arg_exp = argument_exp(burst_width, current_timediff[freq, :], sc_time_freq)
         deriv_arg_erf = deriv_argument_erf(
@@ -2184,6 +2184,7 @@ def deriv2_model_wrt_dm_dm_index(parameters: dict, model: float, component: int 
     current_model = model.spectrum_per_component[:, :, component]
     current_timediff = model.timediff_per_component[:, :, component]
     dm_const = 4149.377593360996
+    dm = parameters["dm"][0] # global parameter.
     dm_index = parameters["dm_index"][0] # global parameter.
     ref_freq = parameters["ref_freq"][component]
 
@@ -2535,7 +2536,6 @@ def deriv2_model_wrt_scattering_index_scattering_index(parameters: dict, model: 
     sc_index = parameters["scattering_index"][0]
     sc_time = parameters["scattering_timescale"][0]
     deriv_mod_int = np.zeros((num_freq, num_time, num_component), dtype=float)
-    amp_pbf = amplitude_pbf(model.freqs, parameters, current_component)
 
     for current_component in range(num_component):
         burst_width = parameters["burst_width"][current_component]
@@ -2543,6 +2543,7 @@ def deriv2_model_wrt_scattering_index_scattering_index(parameters: dict, model: 
         current_amplitude = model.amplitude_per_component[:, :, current_component]
         deriv_first = deriv_model_wrt_scattering_index(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
+        amp_pbf = amplitude_pbf(model.freqs, parameters, current_component)
 
         for freq in range(num_freq):
             freq_ratio = model.freqs[freq] / ref_freq

--- a/fitburst/routines/derivative.py
+++ b/fitburst/routines/derivative.py
@@ -1780,6 +1780,7 @@ def deriv2_model_wrt_burst_width_dm(parameters: dict, model: float, component: i
     sc_time = parameters["scattering_timescale"][0] # global parameter.
     amp_pbf = amplitude_pbf(model.freqs, parameters, component)
 
+    deriv_first = deriv_model_wrt_dm(parameters, model, component, add_all = False)
     deriv_mod = np.zeros(current_model.shape)
 
     # now loop over each frequency and compute mixed-derivative array per channel.
@@ -1806,7 +1807,7 @@ def deriv2_model_wrt_burst_width_dm(parameters: dict, model: float, component: i
             )
 
             # now define terms that contriubte to mixed-partial derivative.
-            term1 = burst_width * current_model[freq, :] / sc_time_freq ** 2
+            term1 = burst_width * deriv_first[freq, :] / sc_time_freq ** 2
             term2 = current_amplitude[freq, :] * amp_pbf[freq] * np.exp(arg_exp) * deriv2_arg_erf * 2 / np.sqrt(np.pi)
             term3 = current_amplitude[freq, :] * amp_pbf[freq] * np.exp(arg_exp) * deriv_arg_erf * deriv_arg_exp * 2 / np.sqrt(np.pi)
             deriv_mod[freq, :] = term1 + term2 + term3
@@ -2296,7 +2297,7 @@ def deriv2_model_wrt_scattering_timescale_scattering_timescale(parameters: dict,
         burst_width = parameters["burst_width"][current_component]
         current_timediff = model.timediff_per_component[:, : , current_component]
         current_amplitude = model.amplitude_per_component[:, :, current_component]
-        deriv_first = deriv_model_wrt_dm_index(parameters, model, current_component, add_all = False)
+        deriv_first = deriv_model_wrt_scattering_timescale(parameters, model, current_component, add_all = False)
         ref_freq = parameters["ref_freq"][current_component]
         amp_pbf = amplitude_pbf(model.freqs, parameters, current_component)
 

--- a/fitburst/routines/profile.py
+++ b/fitburst/routines/profile.py
@@ -149,7 +149,9 @@ def _identify_pbf_regime(arg: float, threshold=-20.0):
     invalid = np.flatnonzero(~flag) if valid.size < flag.size else None
 
     # If possible, convert from indices to slices so that a copy does not occur
-    if (valid[-1] + 1 - valid[0]) == valid.size:
+    if valid.size == 0:
+        valid = None
+    elif (valid[-1] + 1 - valid[0]) == valid.size:
         valid = slice(valid[0], valid[-1]+1)
 
     if invalid is not None and (invalid[-1] + 1 - invalid[0]) == invalid.size:

--- a/fitburst/routines/profile.py
+++ b/fitburst/routines/profile.py
@@ -48,6 +48,7 @@ def compute_profile_gaussian(values: float, mean: float, width: float,
 
     return profile
 
+
 def compute_profile_pbf(time: float, toa: float, width: float, freq: float, ref_freq: float,
                         sc_time_ref: float, sc_index: float = -4., normalize: bool = False) -> float:
     """
@@ -92,23 +93,66 @@ def compute_profile_pbf(time: float, toa: float, width: float, freq: float, ref_
     ratio = width / sc_time
     arg1 = (ratio - z) / np.sqrt(2)
 
-    if normalize:
-        amp_term = np.sqrt(np.pi / 2) * ratio
-    else:
-        amp_term = (freq / ref_freq) ** (-sc_index)
+    amp_term = np.sqrt(np.pi / 2) * ratio if normalize else sc_time_ref / sc_time
 
-    with np.errstate(invalid="ignore", over="ignore"):
-        p1 = amp_term * np.exp(-0.5 * z ** 2) * ss.erfcx(arg1)
+    # Create the output array
+    shp = np.broadcast_shapes(freq.shape, time.shape)
+    profile = np.empty(shp, dtype=float)
 
-    # Use the old method when arg1 is less than roughly -20.0
-    # (corresponding to times much after the arrival time)
-    invalid = arg1 < -20.0
-    if np.any(invalid):
-        arg2 = (ratio / 2 - z) * ratio
-        p2 = amp_term * np.exp(arg2) * ss.erfc(arg1)
+    # Identify regimes where different calculations are needed to prevent numerical overflow
+    regime1, regime2 = _identify_pbf_regime(arg1)
 
-        profile = np.where(invalid, p2, p1)
-    else:
-        profile = p1
+    # Calculate the profile in first regime using the scaled complementary error function
+    if regime1 is not None:
+        profile[..., regime1] = amp_term * np.exp(-0.5 * z[..., regime1] ** 2) * ss.erfcx(arg1[..., regime1])
+
+    # Calculate the profile in second regime using the complementary error function
+    if regime2 is not None:
+        arg2 = (ratio / 2 - z[..., regime2]) * ratio
+        profile[..., regime2] = amp_term * np.exp(arg2) * ss.erfc(arg1[..., regime2])
 
     return profile
+
+
+def _identify_pbf_regime(arg: float, threshold=-20.0):
+    """Identify times where erfcx suffers from numerical overflow.
+
+    Parameters
+    ----------
+    arg : np.ndarray[nfreq, ntime] or np.ndarray[ntime,]
+        Argument to the scaled complementary error function erfcx.
+        In the context of the PBF model, this is given by:
+            (width / sc_time - (time - toa) / width) / np.sqrt(2)
+
+    threshold : float, optional
+        Values of arg less than this threshold will
+        be considered invalid.  Defaults to -20,
+        which works well for float64.
+
+    Returns
+    -------
+    valid : slice, array of int, or None
+        Indices in the time axis where the
+        scaled complimentary error function
+        can be used.  This will be None if
+        no time samples qualify.
+
+    invalid : slice, array of int, or None
+        Indices in the time axis where the
+        scaled complimentary error function
+        suffers from numerical overflow.
+        This will be None if no time samples
+        qualify.
+    """
+    flag = arg > threshold if arg.ndim == 1 else np.all(arg > threshold, axis=0)
+    valid = np.flatnonzero(flag)
+    invalid = np.flatnonzero(~flag) if valid.size < flag.size else None
+
+    # If possible, convert from indices to slices so that a copy does not occur
+    if (valid[-1] + 1 - valid[0]) == valid.size:
+        valid = slice(valid[0], valid[-1]+1)
+
+    if invalid is not None and (invalid[-1] + 1 - invalid[0]) == invalid.size:
+        invalid = slice(invalid[0], invalid[-1]+1)
+
+    return valid, invalid

--- a/fitburst/routines/profile.py
+++ b/fitburst/routines/profile.py
@@ -88,8 +88,8 @@ def compute_profile_pbf(time: float, toa: float, width: float, freq: float, ref_
     """
 
     # evaluate the separate terms that define the PBF.
-    amp_term = (freq / ref_freq) ** (-sc_index) 
     sc_time = sc_time_ref * (freq / ref_freq) ** sc_index
+    amp_term = (freq / ref_freq) ** (-sc_index) #np.sqrt(np.pi / 2) * width / sc_time
     arg_exp = width ** 2 / 2 / sc_time ** 2 - (time - toa) / sc_time
     exp_term = np.exp(arg_exp)
     erf_term = 1 + ss.erf((time - (toa + width ** 2 / sc_time)) / width / np.sqrt(2))

--- a/fitburst/routines/times.py
+++ b/fitburst/routines/times.py
@@ -38,3 +38,44 @@ def compute_arrival_times(parameters: dict, time0: float = 0.) -> list:
         arrival_times_converted += [dt_arrival.strftime("%Y-%m-%d %H:%M:%S.%f")]
 
     return arrival_times_converted
+
+def compute_pulse_duration(parameters: dict, times: float) -> list:
+    """
+    Computes the duration of a pulse based on timestamp and pulse-model data.
+
+    Parameters
+    ----------
+    parameters : dict
+        A dictionary that contains all burst-parameter data.
+
+    time0 : float
+        an array of timestamps defining the time axis of the data subject to modeling.
+
+    Returns
+    -------
+    pulse_durations : list
+        a list containing two-element lists, each containing the indeces that denote the 'start' and 'end' 
+        of duration for the corresponding burst component.
+    """
+
+    num_components = len(parameters["arrival_time"])
+    sc_time = parameters["scattering_timescale"][0] # global parameter
+    pulse_durations = []
+
+    # loop over each component, compute start/end times and corresponding indeces.
+    for current_component in range(num_components):
+        arrival_time = parameters["arrival_time"][current_component]
+        burst_width = parameters["burst_width"][current_component]
+        start = arrival_time - burst_width
+        end = arrival_time + burst_width
+
+        # adjust for scatter-broadening, if relevant.
+        if sc_time != 0.:
+            end += sc_time
+
+        # now determine bin indeces, and correct pre-burst bin if it is equal to the arrival bin.
+        bins = np.digitize([start, end], times)
+        bins[0] -= 1
+        pulse_durations.append(bins.tolist())
+
+    return pulse_durations


### PR DESCRIPTION
This builds on the bugfix-2024-01 branch.  The primary change involves using the scaled complimentary error function instead of the error function when calculating the PBF model.  This avoids problems with numerical overflow previously observed when the scattering time becomes small relative to the burst width.  Before, in order to mitigate these numerical issues, we switched to using a Gaussian model for the time profile when the scattering timescale dropped below some threshold.  However, due to differing normalizations between the Gaussian and PBF model, this introduced a step-like feature in the burst spectrum.  Now, we are able to evaluate the PBF model directly for all scattering timescales.

Also fixes (copy-paste) errors in the calculation of the (burst_width, dm), (scattering_timescale, scattering_timescale), (burst_width, scattering_index), (scattering_index, scattering_index), and (dm, dm_index) mixed partial derivative.  This will impact the calculation of the analytical hessian, and hence parameter uncertainties, for models with scattering.

