### PR TITLE
feat: save hessian matrices to fitburst output json (#1)

### DIFF
--- a/fitburst/pipelines/fitburst_pipeline.py
+++ b/fitburst/pipelines/fitburst_pipeline.py
@@ -566,7 +566,9 @@ for current_iteration in range(num_iterations):
                         "fit_statistics": fitter.fit_statistics,
                         "fit_logistics" : {
                             "weight_range" : weight_range,
-                        }
+                        },
+                        "fit_hessian": fitter.hessian.tolist(),
+                        "fit_hessian_approx": fitter.hessian_approx.tolist(),
                     },
                     out,
                     indent=4


### PR DESCRIPTION
### feat: save hessian matrices to fitburst output json 

This enables the use of covariances for downstream calculations. 

The current version of `fitburst` calculates the Hessian matrix, and prints this to the user. However, it does not save this into the `.json` output. This adds in both the approximate and compute Hessian matrices into the `.json`.  

When reading it back out from the `.json` we recommend `numpy` to format it into a matrix. 

